### PR TITLE
 Improves TypeScript support, and Adds Expression registration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Test Output
+test-ts.js
+
 # Logs
 logs
 *.log

--- a/index.browser.js
+++ b/index.browser.js
@@ -22,7 +22,7 @@
   const is = module.factories.is()
   const blueprint = Object.assign(
     { is },
-    module.factories.numberValidators(),
+    module.factories.numberValidators(is),
     module.factories.blueprint(is)
   )
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -3,8 +3,6 @@
 // Definitions by: Andy Wright <https://github.com/losandes>
 // TypeScript Version: 2.1
 
-/// <reference types="node" />
-
 // blueprint ===================================================================
 
 export interface IValueOrError {
@@ -15,6 +13,7 @@ export interface IValueOrError {
 
 export interface IBlueprint {
   name: string;
+  schema: any;
   validate: (input: any) => IValueOrError
 }
 
@@ -54,6 +53,7 @@ export function registerValidator (name: string, validator: Validator): Validato
  * given validator function
  * @param name - the name of the type
  * @param validator - the validator for testing one instance of this type (must return truthy/falsey)
+ * @returns object - { ${name}: validator, ${name}?: validator, ${name}[]: validator, ${name}[]?: validator }
  */
 export function registerType (name: string, validator: Validator): any;
 
@@ -68,6 +68,7 @@ export function registerBlueprint (name: string, schema: any): IBlueprint;
  * Registers a regular expression validator by name, so it can be used in blueprints
  * @param name - the name of the validator
  * @param expression - the expression that will be  used to validate the values
+ * @returns object - { ${name}: validator, ${name}?: validator, ${name}[]: validator, ${name}[]?: validator }
  */
 export function registerExpression (name: string, expression: RegExp|string): any;
 
@@ -192,7 +193,7 @@ declare namespace is {
   function getType (input: any): boolean;
   function defined (input?: any): boolean;
   function nullOrUndefined (input?: any): boolean;
-  function function (input?: any): boolean;
+  function func (input?: any): boolean;
   function object (input?: any): boolean;
   function array (input?: any): boolean;
   function string (input?: any): boolean;
@@ -203,11 +204,11 @@ declare namespace is {
   function nullOrWhitespace (input?: any): boolean;
   function decimal (input?: any, places?: number): boolean;
 
-  declare namespace not {
+  namespace not {
     function getType (input: any): boolean;
     function defined (input?: any): boolean;
     function nullOrUndefined (input?: any): boolean;
-    function function (input?: any): boolean;
+    function func (input?: any): boolean;
     function object (input?: any): boolean;
     function array (input?: any): boolean;
     function string (input?: any): boolean;

--- a/index.d.ts
+++ b/index.d.ts
@@ -5,6 +5,8 @@
 
 /// <reference types="node" />
 
+// blueprint ===================================================================
+
 export interface IValueOrError {
   err: any | null;
   messages: string[] | null;
@@ -12,7 +14,6 @@ export interface IValueOrError {
 }
 
 export interface IBlueprint {
-  err: any | null;
   name: string;
   validate: (input: any) => IValueOrError
 }
@@ -24,6 +25,197 @@ export interface IValidatorArg {
   root: any;
 }
 
-export function blueprint (name: string, blueprint: any): IBlueprint;
-export function registerValidator (name: string, validator: Function): IValueOrError;
-export function registerBlueprint (name: string, blueprint: any): IValueOrError;
+/**
+ * Validation function that accepts the context being validated, and
+ * either throws if invalid, returns boolean, or returns an IValueOrError
+ * @param context - the value, and object being validated
+ */
+export type Validator = (context: IValidatorArg) => IValueOrError | boolean;
+
+/**
+ * Returns a validator (fluent interface) for validating the input values
+ * against the schema expectations
+ * @param name - the name of the model being validated
+ * @param schema - the type definitions
+ * @param validate.input - the values being validated
+ */
+export function blueprint (name: string, schema: any): IBlueprint;
+
+/**
+ * Registers a validator by name, so it can be used in blueprints
+ * @param name - the name of the validator
+ * @param validator - the validator
+ */
+export function registerValidator (name: string, validator: Validator): Validator;
+
+/**
+ * Registers a validator, a nullable validator, an array validator, and
+ * a nullable array validator based on the given name, using the
+ * given validator function
+ * @param name - the name of the type
+ * @param validator - the validator for testing one instance of this type (must return truthy/falsey)
+ */
+export function registerType (name: string, validator: Validator): any;
+
+/**
+ * Registers a blueprint that can be used as a validator
+ * @param name - the name of the model being validated
+ * @param schema - the type definitions
+ */
+export function registerBlueprint (name: string, schema: any): IBlueprint;
+
+/**
+ * Registers a regular expression validator by name, so it can be used in blueprints
+ * @param name - the name of the validator
+ * @param expression - the expression that will be  used to validate the values
+ */
+export function registerExpression (name: string, expression: RegExp|string): any;
+
+/**
+ * Creates a validator that will verify that a value is greater than the
+ * given minimum
+ * @curried
+ * @param min - the value that the input must be greater than
+ * @param context - the value, and object being validated
+ */
+export function gt (min: number): (context: IValidatorArg) => IValueOrError;
+
+/**
+ * Creates a validator that will verify that a value is greater than, or
+ * equal to the given minimum
+ * @curried
+ * @param min - the value that the input must be greater than, or equal to
+ * @param context - the value, and object being validated
+ */
+export function gte (min: number): (context: IValidatorArg) => IValueOrError;
+
+/**
+ * Creates a validator that will verify that a value is less than the
+ * given maximum
+ * @curried
+ * @param max - the value that the input must be less than
+ * @param context - the value, and object being validated
+ */
+export function lt (max: number): (context: IValidatorArg) => IValueOrError;
+
+/**
+ * Creates a validator that will verify that a value is less than, or
+ * equal to the given minimum
+ * @curried
+ * @param max - the value that the input must be less than, or equal to
+ * @param context - the value, and object being validated
+ */
+export function lte (max: number): (context: IValidatorArg) => IValueOrError;
+
+/**
+ * Creates a validator that will verify that a value is between the
+ * given boundaries. One of [`gt`|`gte`], and one of [`lt`|`lte`] are required.
+ * @curried
+ * @param range.gt - the value that the input must be greater than
+ * @param range.gte - the value that the input must be greater than, or equal to
+ * @param range.lt - the value that the input must be less than
+ * @param range.lte - the value that the input must be less than, or equal to
+ * @param context - the value, and object being validated
+ */
+export function range (range: {
+  gt?: number;
+  gte?: number;
+  lt?: number;
+  lte?: number;
+}): (context: IValidatorArg) => IValueOrError;
+
+/**
+ * Support for null, or undefined numeric comparators
+ */
+// export const optional = { gt, gte, lt, lte, range }
+declare namespace optional {
+  /**
+   * Creates a validator that will verify that a value is greater than the
+   * given minimum
+   * @curried
+   * @param min - the value that the input must be greater than
+   * @param context - the value, and object being validated
+   */
+  function gt (min: number): (context: IValidatorArg) => IValueOrError;
+
+  /**
+   * Creates a validator that will verify that a value is greater than, or
+   * equal to the given minimum
+   * @curried
+   * @param min - the value that the input must be greater than, or equal to
+   * @param context - the value, and object being validated
+   */
+  function gte (min: number): (context: IValidatorArg) => IValueOrError;
+
+  /**
+   * Creates a validator that will verify that a value is less than the
+   * given maximum
+   * @curried
+   * @param max - the value that the input must be less than
+   * @param context - the value, and object being validated
+   */
+  function lt (max: number): (context: IValidatorArg) => IValueOrError;
+
+  /**
+   * Creates a validator that will verify that a value is less than, or
+   * equal to the given minimum
+   * @curried
+   * @param max - the value that the input must be less than, or equal to
+   * @param context - the value, and object being validated
+   */
+  function lte (max: number): (context: IValidatorArg) => IValueOrError;
+
+  /**
+   * Creates a validator that will verify that a value is between the
+   * given boundaries. One of [`gt`|`gte`], and one of [`lt`|`lte`] are required.
+   * @curried
+   * @param range.gt - the value that the input must be greater than
+   * @param range.gte - the value that the input must be greater than, or equal to
+   * @param range.lt - the value that the input must be less than
+   * @param range.lte - the value that the input must be less than, or equal to
+   * @param context - the value, and object being validated
+   */
+  function range (range: {
+    gt?: number;
+    gte?: number;
+    lt?: number;
+    lte?: number;
+  }): (context: IValidatorArg) => IValueOrError;
+}
+
+// is ==========================================================================
+
+/**
+ * Boolean type comparators
+ */
+declare namespace is {
+  function getType (input: any): boolean;
+  function defined (input?: any): boolean;
+  function nullOrUndefined (input?: any): boolean;
+  function function (input?: any): boolean;
+  function object (input?: any): boolean;
+  function array (input?: any): boolean;
+  function string (input?: any): boolean;
+  function boolean (input?: any): boolean;
+  function date (input?: any): boolean;
+  function regexp (input?: any): boolean;
+  function number (input?: any): boolean;
+  function nullOrWhitespace (input?: any): boolean;
+  function decimal (input?: any, places?: number): boolean;
+
+  declare namespace not {
+    function getType (input: any): boolean;
+    function defined (input?: any): boolean;
+    function nullOrUndefined (input?: any): boolean;
+    function function (input?: any): boolean;
+    function object (input?: any): boolean;
+    function array (input?: any): boolean;
+    function string (input?: any): boolean;
+    function boolean (input?: any): boolean;
+    function date (input?: any): boolean;
+    function regexp (input?: any): boolean;
+    function number (input?: any): boolean;
+    function nullOrWhitespace (input?: any): boolean;
+    function decimal (input?: any, places?: number): boolean;
+  }
+}

--- a/index.js
+++ b/index.js
@@ -1,11 +1,13 @@
 const is = require('./src/is').factory()
 const blueprint = require('./src/blueprint').factory(is)
-const numberValidators = require('./src/validators/numbers').factory()
+const numberValidators = require('./src/validators/numbers').factory(is)
 
 require('./src/validators/register-common-types.js').factory(is, blueprint)
 require('./src/validators/register-decimals.js').factory(is, blueprint)
 require('./src/validators/register-expressions.js').factory(blueprint)
 
+// NOTE: if any other validator implement `optional`, they will have to
+// be merged with `numberValidators.optional`
 module.exports = Object.freeze({
   ...{ is },
   ...numberValidators,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@polyn/blueprint",
-  "version": "0.3.1",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -755,6 +755,12 @@
         "lodash": "^4.17.11",
         "to-fast-properties": "^2.0.0"
       }
+    },
+    "@types/chai": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.1.7.tgz",
+      "integrity": "sha512-2Y8uPt0/jwjhQ6EiluT0XCri1Dbplr0ZxfFXUz+ye13gaqE8u5gL5ppao1JrUYr9cIip5S6MvQzBS7Kke7U9VA==",
+      "dev": true
     },
     "abbrev": {
       "version": "1.1.1",
@@ -4530,6 +4536,12 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
       "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
+    },
+    "typescript": {
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.4.5.tgz",
+      "integrity": "sha512-YycBxUb49UUhdNMU5aJ7z5Ej2XGmaIBL0x34vZ82fn3hGvD+bgrMrVDpatgz2f7YxUMJxMkbWxJZeAvDxVe7Vw==",
       "dev": true
     },
     "undefsafe": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "types": "index.d.ts",
   "scripts": {
     "build": "node build.js",
-    "test": "node test.js",
+    "test": "node test.js && npm run test:ts",
+    "test:ts": "tsc -p ./tsconfig.json && node test-ts.js",
     "watch": "nodemon -e js --exec 'node test.js --tap | tap-nyan'"
   },
   "repository": {
@@ -29,6 +30,7 @@
   "devDependencies": {
     "@babel/core": "~7.4.4",
     "@babel/preset-env": "~7.4.4",
+    "@types/chai": "~4.1.7",
     "chai": "~4.2.0",
     "eslint": "~5.16.0",
     "eslint-config-standard": "~12.0.0",
@@ -37,7 +39,8 @@
     "eslint-plugin-promise": "~4.1.1",
     "eslint-plugin-standard": "~4.0.0",
     "nodemon": "~1.19.0",
-    "supposed": "~0.2.0"
+    "supposed": "~0.2.0",
+    "typescript": "~3.4.5"
   },
   "dependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@polyn/blueprint",
-  "version": "1.0.0",
-  "description": "An easy to use validation library for nodejs and browsers",
+  "version": "2.0.0",
+  "description": "An easy to use, flexible, and powerful validation library for nodejs and browsers",
   "main": "index.js",
   "types": "index.d.ts",
   "scripts": {
@@ -27,17 +27,17 @@
     "hilary"
   ],
   "devDependencies": {
-    "@babel/core": "^7.4.4",
-    "@babel/preset-env": "^7.4.4",
-    "chai": "^4.2.0",
-    "eslint": "^5.16.0",
-    "eslint-config-standard": "^12.0.0",
-    "eslint-plugin-import": "^2.17.2",
-    "eslint-plugin-node": "^8.0.1",
-    "eslint-plugin-promise": "^4.1.1",
-    "eslint-plugin-standard": "^4.0.0",
-    "nodemon": "^1.19.0",
-    "supposed": "^0.2.0"
+    "@babel/core": "~7.4.4",
+    "@babel/preset-env": "~7.4.4",
+    "chai": "~4.2.0",
+    "eslint": "~5.16.0",
+    "eslint-config-standard": "~12.0.0",
+    "eslint-plugin-import": "~2.17.2",
+    "eslint-plugin-node": "~8.0.1",
+    "eslint-plugin-promise": "~4.1.1",
+    "eslint-plugin-standard": "~4.0.0",
+    "nodemon": "~1.19.0",
+    "supposed": "~0.2.0"
   },
   "dependencies": {}
 }

--- a/src/blueprint.js
+++ b/src/blueprint.js
@@ -24,6 +24,7 @@ module.exports = {
     class Blueprint {
       constructor (input) {
         this.name = input.name
+        this.schema = input.schema
         this.validate = input.validate
 
         Object.freeze(this)
@@ -133,6 +134,7 @@ module.exports = {
 
       return new Blueprint({
         name,
+        schema,
         validate: validate(name, schema)
       })
     }
@@ -282,7 +284,14 @@ module.exports = {
      * @param {object} schema - the type definitions
      */
     const registerBlueprint = (name, schema) => {
-      const bp = blueprint(name, schema)
+      let bp
+
+      if (schema && schema.schema) {
+        // this must be an instance of a blueprint
+        bp = blueprint(name, schema.schema)
+      } else {
+        bp = blueprint(name, schema)
+      }
 
       if (bp.err) {
         throw bp.err

--- a/src/blueprint.test.js
+++ b/src/blueprint.test.js
@@ -404,7 +404,7 @@ module.exports = (test) => {
         expect(() => registerValidator(1, () => true))
           .to.throw(Error, message)
       },
-      'when given an invalid expression, should throw': (expect) => {
+      'when given an invalid validator, should throw': (expect) => {
         const message = 'registerValidator requires a name {string}, and a validator {function}'
 
         expect(() => registerValidator('registerValidator:invalid', null))
@@ -549,7 +549,7 @@ module.exports = (test) => {
         expect(() => registerType(1, () => true))
           .to.throw(Error, message)
       },
-      'when given an invalid expression, should throw': (expect) => {
+      'when given an invalid validator, should throw': (expect) => {
         const message = 'registerType requires a name {string}, and a validator {function}'
 
         expect(() => registerType('registerType:invalid', null))
@@ -692,7 +692,7 @@ module.exports = (test) => {
         expect(() => registerBlueprint(blueprint('name', { str: 'string' })))
           .to.throw(Error, message)
       },
-      'when given an invalid expression, should throw': (expect) => {
+      'when given an invalid schema, should throw': (expect) => {
         const message = 'blueprint requires a name {string}, and a schema {object}'
 
         expect(() => registerBlueprint('registerBlueprint:invalid', null))
@@ -703,6 +703,19 @@ module.exports = (test) => {
 
         expect(() => registerBlueprint('registerBlueprint:invalid', 1))
           .to.throw(Error, message)
+      },
+      'when given another blueprint as the schema, should register that blueprint\'s schema': (expect) => {
+        const existing = blueprint('registerBlueprint:invalid:nest', {
+          str: 'string'
+        })
+
+        const bp = registerBlueprint(
+          'registerBlueprint:invalid',
+          existing
+        )
+
+        expect(bp.validate({ str: 'str' }).err).to.be.null
+        expect(bp.validate({ str: 'str' }).value).to.deep.equal({ str: 'str' })
       }
     },
     '`registerExpression`': {

--- a/src/blueprint.test.js
+++ b/src/blueprint.test.js
@@ -1,5 +1,11 @@
 module.exports = (test) => {
-  const { blueprint, registerValidator, registerBlueprint, registerType } = test.sut
+  const {
+    blueprint,
+    registerExpression,
+    registerValidator,
+    registerBlueprint,
+    registerType
+  } = test.sut
 
   return test('given `blueprint`', {
     'when a blueprint is constructed with a name, and a blueprint, it should return a `validate` function': (expect) => {
@@ -8,23 +14,17 @@ module.exports = (test) => {
         optionalString: 'string?'
       })
 
-      expect(actual.err).to.be.null
       expect(typeof actual.validate).to.equal('function')
     },
-    'when a blueprint is constructed with an invalid name, it should return an err': (expect) => {
-      const actual = blueprint({
+    'when a blueprint is constructed with an invalid name, it should throw': (expect) => {
+      expect(() => blueprint({
         requiredString: 'string',
         optionalString: 'string?'
-      })
-
-      expect(actual.err).to.not.be.null
-      expect(actual.err.message).to.equal('blueprint requires a name {string}, and a blueprint {object}')
+      })).to.throw(Error, 'blueprint requires a name {string}, and a schema {object}')
     },
-    'when a blueprint is constructed with an invalid blueprint, it should return an err': (expect) => {
-      const actual = blueprint('sut')
-
-      expect(actual.err).to.not.be.null
-      expect(actual.err.message).to.equal('blueprint requires a name {string}, and a blueprint {object}')
+    'when a blueprint is constructed with an invalid blueprint, it should throw': (expect) => {
+      expect(() => blueprint('sut'))
+        .to.throw(Error, 'blueprint requires a name {string}, and a schema {object}')
     },
     'when a blueprint is validated with a valid implementation': {
       when: () => {
@@ -193,6 +193,7 @@ module.exports = (test) => {
             child: {
               custom: (input) => {
                 validatorInput = input
+                return true
               }
             }
           }
@@ -261,203 +262,537 @@ module.exports = (test) => {
       expect(actualInvalid.err.message).to.equal('Invalid sut: bad sut.required1232')
       expect(actualInvalid.value).to.be.null
     },
-    'it should support adding new validators with `registerValidator`': (expect) => {
-      const userBp = blueprint('user', {
-        firstName: 'string',
-        lastName: 'string'
-      })
-      registerValidator('user', ({ key, value }) => {
-        const validation = userBp.validate(value)
+    '`registerValidator`': {
+      'it should support adding new validators': (expect) => {
+        const userBp = blueprint('user', {
+          firstName: 'string',
+          lastName: 'string'
+        })
+        registerValidator('user', ({ key, value }) => {
+          const validation = userBp.validate(value)
 
-        if (validation.err) {
+          if (validation.err) {
+            return {
+              err: validation.err
+            }
+          }
+
           return {
-            err: validation.err
+            err: null,
+            value
+          }
+        })
+        const expected = {
+          user: {
+            firstName: 'John',
+            lastName: 'Doe'
           }
         }
+        const bp = blueprint('sut', {
+          user: 'user'
+        })
+        const actual = bp.validate(expected)
+        const actualInvalid = bp.validate({
+          firstName: 'missing user object'
+        })
 
-        return {
-          err: null,
-          value
-        }
-      })
-      const expected = {
-        user: {
-          firstName: 'John',
-          lastName: 'Doe'
-        }
+        expect(actual.err).to.be.null
+        expect(actual.value).to.deep.equal(expected)
+        expect(actualInvalid.err).to.not.be.null
+        expect(actualInvalid.err.message).to.equal('Invalid sut: Invalid user: user.firstName {string} is invalid, user.lastName {string} is invalid')
+        expect(actualInvalid.value).to.be.null
+      },
+      'it should pass `key`, `value`, `input`, and `root` to registered validators': (expect) => {
+        let actual
+        registerValidator('registerValidatorArgs', ({ key, value, input, root }) => {
+          actual = { key, value, input, root }
+          return { err: null }
+        })
+
+        blueprint('sut', {
+          args: 'registerValidatorArgs'
+        }).validate({
+          args: 'args-value',
+          other: 'other-value'
+        })
+
+        expect(actual).to.deep.equal({
+          key: 'sut.args',
+          value: 'args-value',
+          input: { args: 'args-value', other: 'other-value' },
+          root: { args: 'args-value', other: 'other-value' }
+        })
+      },
+      'it should return an error if a validator doesn\'t return anything': (expect) => {
+        registerValidator('registerValidatorWithNoReturn', () => {})
+        const actual = blueprint('sut', {
+          something: 'registerValidatorWithNoReturn'
+        }).validate({
+          something: 'value'
+        })
+
+        expect(actual.err).to.not.be.null
+        expect(actual.err.message).to.equal('Invalid sut: ValidationError: the validator for sut.something didn\'t return a value')
+      },
+      'should be able to intercept values': (expect) => {
+        registerValidator('registerValidatorInterceptor', () => {
+          return {
+            err: null,
+            value: 42
+          }
+        })
+        const actual = blueprint('sut', {
+          something: 'registerValidatorInterceptor'
+        }).validate({
+          something: 'value'
+        })
+
+        expect(actual.err).to.be.null
+        expect(actual.value.something).to.equal(42)
+      },
+      'should support boolean validators': (expect) => {
+        registerValidator('registerValidator:boolean-validators', ({ key, value }) => {
+          return value === 1 ? true : false // eslint-disable-line no-unneeded-ternary
+        })
+
+        const bp = blueprint('sut', {
+          args: 'registerValidator:boolean-validators'
+        })
+
+        expect(bp.validate({ args: 0 }).err).to.not.be.null
+        expect(bp.validate({ args: 0 }).err.message).to.equal('Invalid sut: sut.args is invalid')
+        expect(bp.validate({ args: 1 }).err).to.be.null
+        expect(bp.validate({ args: 1 }).value.args).to.equal(1)
+      },
+      'if the validator returns an object and result.value isn\'t set, you\'re bummed': (expect) => {
+        registerValidator('registerValidatorWithNoReturn', () => {
+          return {
+            err: null,
+            bvalue: 42
+          }
+        })
+        const actual = blueprint('sut', {
+          something: 'registerValidatorWithNoReturn'
+        }).validate({
+          something: 'value'
+        })
+
+        expect(actual.err).to.be.null
+        expect(actual.value.something).to.equal(undefined)
+      },
+      'if the validator throws, it should use the err': (expect) => {
+        registerValidator('registerValidator:throws', ({ key, value }) => {
+          throw new Error(`I don't like your ${key}:${value}`)
+        })
+
+        const bp = blueprint('sut', {
+          args: 'registerValidator:throws'
+        })
+
+        expect(bp.validate({ args: 0 }).err).to.not.be.null
+        expect(bp.validate({ args: 0 }).err.message).to.equal('Invalid sut: I don\'t like your sut.args:0')
+      },
+      'when given an invalid name, should throw': (expect) => {
+        const message = 'registerValidator requires a name {string}, and a validator {function}'
+
+        expect(() => registerValidator(null, () => true))
+          .to.throw(Error, message)
+
+        expect(() => registerValidator(() => true))
+          .to.throw(Error, message)
+
+        expect(() => registerValidator(1, () => true))
+          .to.throw(Error, message)
+      },
+      'when given an invalid expression, should throw': (expect) => {
+        const message = 'registerValidator requires a name {string}, and a validator {function}'
+
+        expect(() => registerValidator('registerValidator:invalid', null))
+          .to.throw(Error, message)
+
+        expect(() => registerValidator('registerValidator:invalid'))
+          .to.throw(Error, message)
+
+        expect(() => registerValidator('registerValidator:invalid', 1))
+          .to.throw(Error, message)
+      },
+      'should return the validator': (expect) => {
+        const validator = registerValidator('registerValidatorReturns', () => { return { value: 42 } })
+        expect(validator().value).to.equal(42)
       }
-      const bp = blueprint('sut', {
-        user: 'user'
-      })
-      const actual = bp.validate(expected)
-      const actualInvalid = bp.validate({
-        firstName: 'missing user object'
-      })
-
-      expect(actual.err).to.be.null
-      expect(actual.value).to.deep.equal(expected)
-      expect(actualInvalid.err).to.not.be.null
-      expect(actualInvalid.err.message).to.equal('Invalid sut: Invalid user: user.firstName {string} is invalid, user.lastName {string} is invalid')
-      expect(actualInvalid.value).to.be.null
     },
-    'it should pass `key`, `value`, `input`, and `root` to registered validators': (expect) => {
-      let actual
-      registerValidator('registerValidatorArgs', ({ key, value, input, root }) => {
-        actual = { key, value, input, root }
-        return { err: null }
-      })
+    '`registerType`': {
+      'should support boolean validators': (expect) => {
+        registerType('registerType:boolean-validators', ({ key, value }) => {
+          return value ? true : false // eslint-disable-line no-unneeded-ternary
+        })
 
-      blueprint('sut', {
-        args: 'registerValidatorArgs'
-      }).validate({
-        args: 'args-value',
-        other: 'other-value'
-      })
+        const bp = blueprint('sut', {
+          args: 'registerType:boolean-validators'
+        })
 
-      expect(actual).to.deep.equal({
-        key: 'sut.args',
-        value: 'args-value',
-        input: { args: 'args-value', other: 'other-value' },
-        root: { args: 'args-value', other: 'other-value' }
-      })
-    },
-    'it should NOT throw if a validator doesn\'t return anything': (expect) => {
-      registerValidator('registerValidatorWithNoReturn', () => {})
-      const actual = blueprint('sut', {
-        something: 'registerValidatorWithNoReturn'
-      }).validate({
-        something: 'value'
-      })
+        expect(bp.validate({ args: 0 }).err).to.not.be.null
+        expect(bp.validate({ args: 0 }).err.message).to.equal('Invalid sut: sut.args {registerType:boolean-validators} is required')
+        expect(bp.validate({ args: 1 }).err).to.be.null
+        expect(bp.validate({ args: 1 }).value.args).to.equal(1)
+      },
+      'should support {err,value} validators': (expect) => {
+        registerType('registerType:{err,value}-validators', ({ key, value }) => {
+          return value
+            ? {
+              err: null,
+              value
+            }
+            : {
+              err: new Error(`${key}.... BOOM!`),
+              value: null
+            }
+        })
 
-      expect(actual.err).to.be.null
-    },
-    'it should return the input value if the validator doesn\'t return anything': (expect) => {
-      registerValidator('registerValidatorWithNoReturn', () => {})
-      const actual = blueprint('sut', {
-        something: 'registerValidatorWithNoReturn'
-      }).validate({
-        something: 'value'
-      })
+        const bp = blueprint('sut', {
+          args: 'registerType:{err,value}-validators'
+        })
 
-      expect(actual.err).to.be.null
-      expect(actual.value.something).to.equal('value')
-    },
-    '`registerValidator` should be able to intercept values': (expect) => {
-      registerValidator('registerValidatorInterceptor', () => {
-        return {
-          err: null,
-          value: 42
+        expect(bp.validate({ args: 0 }).err).to.not.be.null
+        expect(bp.validate({ args: 0 }).err.message).to.equal('Invalid sut: sut.args.... BOOM!')
+        expect(bp.validate({ args: 1 }).err).to.be.null
+        expect(bp.validate({ args: 1 }).value.args).to.equal(1)
+      },
+      'should add instance, nullable instance, array, and nullable array types': (expect) => {
+        registerType('registerType:all-the-things', ({ key, value }) => {
+          return value === 1 ? true : false // eslint-disable-line no-unneeded-ternary
+        })
+
+        const bp = blueprint('sut', {
+          required: 'registerType:all-the-things',
+          optional: 'registerType:all-the-things?',
+          requiredArray: 'registerType:all-the-things[]',
+          optionalArray: 'registerType:all-the-things[]?'
+        })
+
+        const expected = {
+          required: 1,
+          optional: 1,
+          requiredArray: [1, 1, 1],
+          optionalArray: [1, 1, 1]
         }
-      })
-      const actual = blueprint('sut', {
-        something: 'registerValidatorInterceptor'
-      }).validate({
-        something: 'value'
-      })
 
-      expect(actual.err).to.be.null
-      expect(actual.value.something).to.equal(42)
-    },
-    'if the validator returns an object and result.value isn\'t set, you\'re bummed': (expect) => {
-      registerValidator('registerValidatorWithNoReturn', () => {
-        return {
-          err: null,
-          bvalue: 42
-        }
-      })
-      const actual = blueprint('sut', {
-        something: 'registerValidatorWithNoReturn'
-      }).validate({
-        something: 'value'
-      })
+        const validActual = bp.validate(expected)
 
-      expect(actual.err).to.be.null
-      expect(actual.value.something).to.equal(undefined)
-    },
-    'it should support adding blueprints as new validators with `registerBlueprint`': (expect) => {
-      registerBlueprint('registerBlueprint:user', {
-        firstName: 'string',
-        lastName: 'string'
-      })
-      const expected = {
-        user: {
-          firstName: 'John',
-          lastName: 'Doe'
+        const invalidActual = bp.validate({
+          required: 0,
+          optional: 0,
+          requiredArray: [1, 1, 0],
+          optionalArray: [1, 0, 1]
+        })
+
+        expect(validActual.err).to.be.null
+        expect(validActual.value).to.deep.equal(expected)
+        expect(invalidActual.err).to.not.be.null
+        expect(invalidActual.err.message).to.equal('Invalid sut: sut.required {registerType:all-the-things} is required, sut.optional must be a registerType:all-the-things if present, All values for sut.requiredArray must be {registerType:all-the-things}: All values for sut.requiredArray must be {registerType:all-the-things}, All values for sut.optionalArray must be {registerType:all-the-things}: All values for sut.optionalArray must be {registerType:all-the-things}')
+      },
+      'it should pass `key`, `value`, `input`, and `root` to registered types': (expect) => {
+        let actual
+        registerType('registerTypeArgs', ({ key, value, input, root }) => {
+          actual = { key, value, input, root }
+          return { err: null }
+        })
+
+        blueprint('sut', {
+          args: 'registerTypeArgs'
+        }).validate({
+          args: 'args-value',
+          other: 'other-value'
+        })
+
+        expect(actual).to.deep.equal({
+          key: 'sut.args',
+          value: 'args-value',
+          input: { args: 'args-value', other: 'other-value' },
+          root: { args: 'args-value', other: 'other-value' }
+        })
+      },
+      'should be able to intercept values': (expect) => {
+        registerType('registerTypeInterceptor', ({ value }) => {
+          return { err: null, value: value && value.trim() }
+        })
+
+        const expected = {
+          requiredName: 'whitespace',
+          optionalName: 'whitespace',
+          requiredArray: ['whitespace'],
+          optionalArray: ['whitespace']
         }
+        const actual = blueprint('registerTypeInterceptor-test', {
+          requiredName: 'registerTypeInterceptor',
+          optionalName: 'registerTypeInterceptor?',
+          requiredArray: 'registerTypeInterceptor[]',
+          optionalArray: 'registerTypeInterceptor[]?'
+        }).validate({
+          requiredName: '  whitespace ',
+          optionalName: '  whitespace ',
+          requiredArray: ['  whitespace '],
+          optionalArray: ['  whitespace ']
+        })
+
+        expect(actual.value).to.deep.equal(expected)
+      },
+      'when given an invalid name, should throw': (expect) => {
+        const message = 'registerType requires a name {string}, and a validator {function}'
+
+        expect(() => registerType(null, () => true))
+          .to.throw(Error, message)
+
+        expect(() => registerType(() => true))
+          .to.throw(Error, message)
+
+        expect(() => registerType(1, () => true))
+          .to.throw(Error, message)
+      },
+      'when given an invalid expression, should throw': (expect) => {
+        const message = 'registerType requires a name {string}, and a validator {function}'
+
+        expect(() => registerType('registerType:invalid', null))
+          .to.throw(Error, message)
+
+        expect(() => registerType('registerType:invalid'))
+          .to.throw(Error, message)
+
+        expect(() => registerType('registerType:invalid', 1))
+          .to.throw(Error, message)
+      },
+      'should return the validators': (expect) => {
+        const types = registerType('registerTypeReturns', ({ value }) => { return { value } })
+
+        expect(types['registerTypeReturns']({ value: 42 }).value).to.equal(42)
+        expect(types['registerTypeReturns?']({ value: 42 }).value).to.equal(42)
+        expect(types['registerTypeReturns[]']({ value: [42] }).value[0]).to.equal(42)
+        expect(types['registerTypeReturns[]?']({ value: [42] }).value[0]).to.equal(42)
       }
-      const bp = blueprint('sut', {
-        user: 'registerBlueprint:user'
-      })
-      const actual = bp.validate(expected)
-      const actualInvalid = bp.validate({
-        firstName: 'missing user object'
-      })
-
-      expect(actual.err).to.be.null
-      expect(actual.value).to.deep.equal(expected)
-      expect(actualInvalid.err).to.not.be.null
-      expect(actualInvalid.err.message).to.equal('Invalid sut: Invalid registerBlueprint:user: registerBlueprint:user.firstName {string} is invalid, registerBlueprint:user.lastName {string} is invalid')
-      expect(actualInvalid.value).to.be.null
     },
-    '`registerBlueprint` should support null values': (expect) => {
-      registerBlueprint('registerBlueprint:null:user', {
-        firstName: 'string',
-        lastName: 'string'
-      })
-      const actual = blueprint('sut', {
-        user: 'registerBlueprint:null:user?'
-      }).validate({
-        user: null
-      })
+    '`registerBlueprint`': {
+      'it should support adding blueprints as new validators with `registerBlueprint`': (expect) => {
+        registerBlueprint('registerBlueprint:user', {
+          firstName: 'string',
+          lastName: 'string'
+        })
+        const expected = {
+          user: {
+            firstName: 'John',
+            lastName: 'Doe'
+          }
+        }
+        const bp = blueprint('sut', {
+          user: 'registerBlueprint:user'
+        })
+        const actual = bp.validate(expected)
+        const actualInvalid = bp.validate({
+          firstName: 'missing user object'
+        })
 
-      expect(actual.err).to.be.null
-    },
-    '`registerBlueprint` should support arrays': (expect) => {
-      registerBlueprint('registerBlueprint:array:user', {
-        firstName: 'string',
-        lastName: 'string'
-      })
-      const bp = blueprint('sut', {
-        users: 'registerBlueprint:array:user[]'
-      })
+        expect(actual.err).to.be.null
+        expect(actual.value).to.deep.equal(expected)
+        expect(actualInvalid.err).to.not.be.null
+        expect(actualInvalid.err.message).to.equal('Invalid sut: Invalid registerBlueprint:user: registerBlueprint:user.firstName {string} is invalid, registerBlueprint:user.lastName {string} is invalid')
+        expect(actualInvalid.value).to.be.null
+      },
+      'should support null values': (expect) => {
+        registerBlueprint('registerBlueprint:null:user', {
+          firstName: 'string',
+          lastName: 'string'
+        })
+        const actual = blueprint('sut', {
+          user: 'registerBlueprint:null:user?'
+        }).validate({
+          user: null
+        })
 
-      const expected = {
-        users: [{
+        expect(actual.err).to.be.null
+      },
+      'should support arrays': (expect) => {
+        registerBlueprint('registerBlueprint:array:user', {
+          firstName: 'string',
+          lastName: 'string'
+        })
+        const bp = blueprint('sut', {
+          users: 'registerBlueprint:array:user[]'
+        })
+
+        const expected = {
+          users: [{
+            firstName: 'John',
+            lastName: 'Doe'
+          }, {
+            firstName: 'John',
+            lastName: 'Doe'
+          }]
+        }
+        const actual = bp.validate(expected)
+        const actualInvalid = bp.validate({
+          users: [{
+            firstName: 'John',
+            lastName: 'Doe'
+          }, {
+            firstName: 'John'
+          }]
+        })
+
+        expect(actual.err).to.be.null
+        expect(actual.value).to.deep.equal(expected)
+        expect(actualInvalid.err).to.not.be.null
+        expect(actualInvalid.err.message).to.equal('Invalid sut: All values for sut.users must be {registerBlueprint:array:user}: Invalid registerBlueprint:array:user: registerBlueprint:array:user.lastName {string} is invalid')
+        expect(actualInvalid.value).to.be.null
+      },
+      'should support nullable arrays': (expect) => {
+        registerBlueprint('registerBlueprint:null:array:user', {
+          firstName: 'string',
+          lastName: 'string'
+        })
+        const actual = blueprint('sut', {
+          users: 'registerBlueprint:null:array:user[]?'
+        }).validate({
+          users: null
+        })
+
+        expect(actual.err).to.be.null
+      },
+      'should return the blueprint': (expect) => {
+        const bp = registerBlueprint('registerBlueprint:returns', {
+          firstName: 'string',
+          lastName: 'string'
+        })
+        const expected = {
           firstName: 'John',
           lastName: 'Doe'
-        }, {
-          firstName: 'John',
-          lastName: 'Doe'
-        }]
+        }
+
+        const actual = bp.validate(expected)
+        const actualInvalid = bp.validate({
+          firstName: 'missing lastName'
+        })
+
+        expect(actual.err).to.be.null
+        expect(actual.value).to.deep.equal(expected)
+        expect(actualInvalid.err).to.not.be.null
+        expect(actualInvalid.err.message).to.equal('Invalid registerBlueprint:returns: registerBlueprint:returns.lastName {string} is invalid')
+        expect(actualInvalid.value).to.be.null
+      },
+      'when given an invalid name, should throw': (expect) => {
+        const message = 'blueprint requires a name {string}, and a schema {object}'
+
+        expect(() => registerBlueprint(null, { str: 'string' }))
+          .to.throw(Error, message)
+
+        expect(() => registerBlueprint({ str: 'string' }))
+          .to.throw(Error, message)
+
+        expect(() => registerBlueprint(1, { str: 'string' }))
+          .to.throw(Error, message)
+
+        expect(() => registerBlueprint(blueprint('name', { str: 'string' })))
+          .to.throw(Error, message)
+      },
+      'when given an invalid expression, should throw': (expect) => {
+        const message = 'blueprint requires a name {string}, and a schema {object}'
+
+        expect(() => registerBlueprint('registerBlueprint:invalid', null))
+          .to.throw(Error, message)
+
+        expect(() => registerBlueprint('registerBlueprint:invalid'))
+          .to.throw(Error, message)
+
+        expect(() => registerBlueprint('registerBlueprint:invalid', 1))
+          .to.throw(Error, message)
       }
-      const actual = bp.validate(expected)
-      const actualInvalid = bp.validate({
-        users: [{
-          firstName: 'John',
-          lastName: 'Doe'
-        }, {
-          firstName: 'John'
-        }]
-      })
-
-      expect(actual.err).to.be.null
-      expect(actual.value).to.deep.equal(expected)
-      expect(actualInvalid.err).to.not.be.null
-      expect(actualInvalid.err.message).to.equal('Invalid sut: All values for sut.users must be {registerBlueprint:array:user}: Invalid registerBlueprint:array:user: registerBlueprint:array:user.lastName {string} is invalid')
-      expect(actualInvalid.value).to.be.null
     },
-    '`registerBlueprint` should support nullable arrays': (expect) => {
-      registerBlueprint('registerBlueprint:null:array:user', {
-        firstName: 'string',
-        lastName: 'string'
-      })
-      const actual = blueprint('sut', {
-        users: 'registerBlueprint:null:array:user[]?'
-      }).validate({
-        users: null
-      })
+    '`registerExpression`': {
+      'should support inline expressions': (expect) => {
+        registerExpression('registerExpression:inline', /^book|movie$/i)
+        const bp = blueprint('sut', {
+          arg: 'registerExpression:inline'
+        })
 
-      expect(actual.err).to.be.null
+        expect(bp.validate({ arg: 1 }).err).to.not.be.null
+        expect(bp.validate({ arg: 1 }).err.message).to.equal('Invalid sut: sut.arg does not match /^book|movie$/i')
+        expect(bp.validate({ arg: 'book' }).err).to.be.null
+        expect(bp.validate({ arg: 'book' }).value.arg).to.equal('book')
+        expect(bp.validate({ arg: 'movie' }).err).to.be.null
+        expect(bp.validate({ arg: 'movie' }).value.arg).to.equal('movie')
+      },
+      'should support expression strings': (expect) => {
+        registerExpression('registerExpression:string', '^book$')
+        const bp = blueprint('sut', {
+          arg: 'registerExpression:string'
+        })
+
+        expect(bp.validate({ arg: 1 }).err).to.not.be.null
+        expect(bp.validate({ arg: 1 }).err.message).to.equal('Invalid sut: sut.arg does not match /^book$/')
+        expect(bp.validate({ arg: 'book' }).err).to.be.null
+        expect(bp.validate({ arg: 'book' }).value.arg).to.equal('book')
+      },
+      'should add instance, nullable instance, array, and nullable array types': (expect) => {
+        registerExpression('registerExpression:all-the-things', /^book$/i)
+
+        const bp = blueprint('sut', {
+          required: 'registerExpression:all-the-things',
+          optional: 'registerExpression:all-the-things?',
+          requiredArray: 'registerExpression:all-the-things[]',
+          optionalArray: 'registerExpression:all-the-things[]?'
+        })
+
+        const expected = {
+          required: 'book',
+          optional: 'book',
+          requiredArray: ['book', 'book', 'book'],
+          optionalArray: ['book', 'book', 'book']
+        }
+
+        const validActual = bp.validate(expected)
+
+        const invalidActual = bp.validate({
+          required: 'movie',
+          optional: 'movie',
+          requiredArray: ['movie', 'movie', 'movie'],
+          optionalArray: ['movie', 'movie', 'movie']
+        })
+
+        expect(validActual.err).to.be.null
+        expect(validActual.value).to.deep.equal(expected)
+        expect(invalidActual.err).to.not.be.null
+        expect(invalidActual.err.message).to.equal('Invalid sut: sut.required does not match /^book$/i, sut.optional does not match /^book$/i, All values for sut.requiredArray must be {registerExpression:all-the-things}: sut.requiredArray[0] does not match /^book$/i, sut.requiredArray[1] does not match /^book$/i, sut.requiredArray[2] does not match /^book$/i, All values for sut.optionalArray must be {registerExpression:all-the-things}: sut.optionalArray[0] does not match /^book$/i, sut.optionalArray[1] does not match /^book$/i, sut.optionalArray[2] does not match /^book$/i')
+      },
+      'when given an invalid name, should throw': (expect) => {
+        const message = 'registerExpression requires a name {string}, and an expression {expression}'
+
+        expect(() => registerExpression(null, /^book|movie$/i))
+          .to.throw(Error, message)
+
+        expect(() => registerExpression(/^book|movie$/i))
+          .to.throw(Error, message)
+
+        expect(() => registerExpression(1, /^book|movie$/i))
+          .to.throw(Error, message)
+      },
+      'when given an invalid expression, should throw': (expect) => {
+        const message = 'registerExpression requires a name {string}, and an expression {expression}'
+
+        expect(() => registerExpression('registerExpression:invalid', null))
+          .to.throw(Error, message)
+
+        expect(() => registerExpression('registerExpression:invalid'))
+          .to.throw(Error, message)
+
+        expect(() => registerExpression('registerExpression:invalid', 1))
+          .to.throw(Error, message)
+      },
+      'should return the validators': (expect) => {
+        const types = registerExpression('registerExpressionReturns', /^book$/)
+
+        expect(types['registerExpressionReturns']({ value: 'book' }).value).to.equal('book')
+        expect(types['registerExpressionReturns?']({ value: 'book' }).value).to.equal('book')
+        expect(types['registerExpressionReturns[]']({ value: ['book'] }).value[0]).to.equal('book')
+        expect(types['registerExpressionReturns[]?']({ value: ['book'] }).value[0]).to.equal('book')
+      }
     },
     'it should not throw when a null object is validated': (expect) => {
       const actual = blueprint('sut', { string: 'string' })
@@ -465,121 +800,6 @@ module.exports = (test) => {
 
       expect(actual.err).to.not.be.null
       expect(actual.err.message).to.equal('Invalid sut: sut.string {string} is invalid')
-    },
-    '`registerType` should support boolean validators': (expect) => {
-      registerType('registerType:boolean-validators', ({ key, value }) => {
-        return value ? true : false // eslint-disable-line no-unneeded-ternary
-      })
-
-      const bp = blueprint('sut', {
-        args: 'registerType:boolean-validators'
-      })
-
-      expect(bp.validate({ args: 0 }).err).to.not.be.null
-      expect(bp.validate({ args: 0 }).err.message).to.equal('Invalid sut: sut.args {registerType:boolean-validators} is required')
-      expect(bp.validate({ args: 1 }).err).to.be.null
-      expect(bp.validate({ args: 1 }).value.args).to.equal(1)
-    },
-    '`registerType` should support {err,value} validators': (expect) => {
-      registerType('registerType:{err,value}-validators', ({ key, value }) => {
-        return value
-          ? {
-            err: null,
-            value
-          }
-          : {
-            err: new Error(`${key}.... BOOM!`),
-            value: null
-          }
-      })
-
-      const bp = blueprint('sut', {
-        args: 'registerType:{err,value}-validators'
-      })
-
-      expect(bp.validate({ args: 0 }).err).to.not.be.null
-      expect(bp.validate({ args: 0 }).err.message).to.equal('Invalid sut: sut.args.... BOOM!')
-      expect(bp.validate({ args: 1 }).err).to.be.null
-      expect(bp.validate({ args: 1 }).value.args).to.equal(1)
-    },
-    '`registerType` should add instance, nullable instance, array, and nullable array types': (expect) => {
-      registerType('registerType:all-the-things', ({ key, value }) => {
-        return value === 1 ? true : false // eslint-disable-line no-unneeded-ternary
-      })
-
-      const bp = blueprint('sut', {
-        required: 'registerType:all-the-things',
-        optional: 'registerType:all-the-things?',
-        requiredArray: 'registerType:all-the-things[]',
-        optionalArray: 'registerType:all-the-things[]?'
-      })
-
-      const expected = {
-        required: 1,
-        optional: 1,
-        requiredArray: [1, 1, 1],
-        optionalArray: [1, 1, 1]
-      }
-
-      const validActual = bp.validate(expected)
-
-      const invalidActual = bp.validate({
-        required: 0,
-        optional: 0,
-        requiredArray: [1, 1, 0],
-        optionalArray: [1, 0, 1]
-      })
-
-      expect(validActual.err).to.be.null
-      expect(validActual.value).to.deep.equal(expected)
-      expect(invalidActual.err).to.not.be.null
-      expect(invalidActual.err.message).to.equal('Invalid sut: sut.required {registerType:all-the-things} is required, sut.optional must be a registerType:all-the-things if present, All values for sut.requiredArray must be {registerType:all-the-things}: All values for sut.requiredArray must be {registerType:all-the-things}, All values for sut.optionalArray must be {registerType:all-the-things}: All values for sut.optionalArray must be {registerType:all-the-things}')
-    },
-    'it should pass `key`, `value`, `input`, and `root` to registered types': (expect) => {
-      let actual
-      registerType('registerTypeArgs', ({ key, value, input, root }) => {
-        actual = { key, value, input, root }
-        return { err: null }
-      })
-
-      blueprint('sut', {
-        args: 'registerTypeArgs'
-      }).validate({
-        args: 'args-value',
-        other: 'other-value'
-      })
-
-      expect(actual).to.deep.equal({
-        key: 'sut.args',
-        value: 'args-value',
-        input: { args: 'args-value', other: 'other-value' },
-        root: { args: 'args-value', other: 'other-value' }
-      })
-    },
-    '`registerType` should be able to intercept values': (expect) => {
-      registerType('registerTypeInterceptor', ({ value }) => {
-        return { err: null, value: value && value.trim() }
-      })
-
-      const expected = {
-        requiredName: 'whitespace',
-        optionalName: 'whitespace',
-        requiredArray: ['whitespace'],
-        optionalArray: ['whitespace']
-      }
-      const actual = blueprint('registerTypeInterceptor-test', {
-        requiredName: 'registerTypeInterceptor',
-        optionalName: 'registerTypeInterceptor?',
-        requiredArray: 'registerTypeInterceptor[]',
-        optionalArray: 'registerTypeInterceptor[]?'
-      }).validate({
-        requiredName: '  whitespace ',
-        optionalName: '  whitespace ',
-        requiredArray: ['  whitespace '],
-        optionalArray: ['  whitespace ']
-      })
-
-      expect(actual.value).to.deep.equal(expected)
     }
   })
 }

--- a/src/is.js
+++ b/src/is.js
@@ -8,6 +8,7 @@ module.exports = {
       defined: undefined,
       nullOrUndefined: undefined,
       function: undefined,
+      func: undefined,
       object: undefined,
       array: undefined,
       string: undefined,
@@ -21,6 +22,7 @@ module.exports = {
         defined: undefined,
         nullOrUndefined: undefined,
         function: undefined,
+        func: undefined,
         object: undefined,
         array: undefined,
         string: undefined,
@@ -96,9 +98,13 @@ module.exports = {
       return is.getType(obj) === 'function'
     }
 
+    is.func = is.function // typescript support
+
     is.not.function = function (obj) {
       return is.function(obj) === false
     }
+
+    is.not.func = is.not.function // typescript support
 
     is.object = function (obj) {
       return is.getType(obj) === 'object'

--- a/src/validators/numbers-gte.test.js
+++ b/src/validators/numbers-gte.test.js
@@ -1,37 +1,58 @@
 module.exports = (test) => {
-  const { blueprint, gte } = test.sut
+  const { blueprint, gte, optional } = test.sut
 
   const gte20Bp = blueprint('sut', {
     gte20: gte(20)
   })
 
+  const expectValue = (expected, actual) => (expect) => {
+    expect(actual.err).to.be.null
+    expect(actual.value).to.deep.equal(expected)
+  }
+
+  const expectError = (actual) => (expect) => {
+    expect(actual.err).to.not.be.null
+    expect(actual.err.message)
+      .to.equal('Invalid sut: sut.gte20 must be greater than, or equal to 20')
+  }
+
+  const expectToThrow = (actual) => (expect) => {
+    expect(actual).to.throw(Error, 'gte requires a minimum number to compare values to')
+  }
+
   return test('given `gte`', {
-    'when given a value less than the minimum, it should return an error': (expect) => {
-      expect(gte20Bp.validate({ gte20: 19 }).err).to.not.be.null
-      expect(gte20Bp.validate({ gte20: 19 }).err.message)
-        .to.equal('Invalid sut: sut.gte20 must be greater than, or equal to 20')
+    'when defined (`gte(20)`)': {
+      'it should throw if the minimum is undefined':
+        expectToThrow(() => { blueprint('sut', { gte20: gte() }) }),
+      'it should throw if the minimum is null':
+        expectToThrow(() => { blueprint('sut', { gte20: gte(null) }) }),
+      'it should throw if the minimum is NaN':
+        expectToThrow(() => { blueprint('sut', { gte20: gte('string') }) })
     },
-    'when given a value equal to the minimum, it should return an error': {
-      when: () => gte20Bp.validate({ gte20: 20 }),
-      'it should NOT return an error': (expect) => (err, actual) => {
-        expect(err).to.be.null
-        expect(actual.err).to.be.null
-      },
-      'it should return the value': (expect) => (err, actual) => {
-        expect(err).to.be.null
-        expect(actual.value.gte20).to.equal(20)
-      }
+    'when `blueprint.validate` is called': {
+      'it should return a value if the value is greater than the minimum':
+        expectValue({ gte20: 21 }, gte20Bp.validate({ gte20: 21 })),
+      'it should return a value if the value is equal to the minimum':
+        expectValue({ gte20: 20 }, gte20Bp.validate({ gte20: 20 })),
+      'it should return an error if the value is less than the minimum':
+        expectError(gte20Bp.validate({ gte20: 19 })),
+      'it should return an error if the value is undefined':
+        expectError(gte20Bp.validate({ gte20: undefined })),
+      'it should return an error if the value is null':
+        expectError(gte20Bp.validate({ gte20: null })),
+      'it should return an error if the value is NaN':
+        expectError(gte20Bp.validate({ gte20: 'string' })),
+      'it should return an error if the value is not strictly a number':
+        expectError(gte20Bp.validate({ gte20: '21' }))
     },
-    'when given a value greater than the minimum': {
-      when: () => gte20Bp.validate({ gte20: 21 }),
-      'it should NOT return an error': (expect) => (err, actual) => {
-        expect(err).to.be.null
-        expect(actual.err).to.be.null
-      },
-      'it should return the value': (expect) => (err, actual) => {
-        expect(err).to.be.null
-        expect(actual.value.gte20).to.equal(21)
-      }
+    'when the `optional` prefix is used, it should allow null and undefined': (expect) => {
+      const gte20Bp = blueprint('sut', {
+        gte20: gte(20),
+        maybeGte20: optional.gte(20)
+      })
+      expect(gte20Bp.validate({ gte20: 21 }).err).to.be.null
+      expect(gte20Bp.validate({ gte20: 21 }).value.maybeGte20).to.be.undefined
+      expect(gte20Bp.validate({ gte20: 21, maybeGte20: null }).value.maybeGte20).to.be.null
     }
   })
 }

--- a/src/validators/numbers-lt.test.js
+++ b/src/validators/numbers-lt.test.js
@@ -1,31 +1,58 @@
 module.exports = (test) => {
-  const { blueprint, lt } = test.sut
+  const { blueprint, lt, optional } = test.sut
 
   const lt20Bp = blueprint('sut', {
     lt20: lt(20)
   })
 
+  const expectValue = (expected, actual) => (expect) => {
+    expect(actual.err).to.be.null
+    expect(actual.value).to.deep.equal(expected)
+  }
+
+  const expectError = (actual) => (expect) => {
+    expect(actual.err).to.not.be.null
+    expect(actual.err.message)
+      .to.equal('Invalid sut: sut.lt20 must be less than 20')
+  }
+
+  const expectToThrow = (actual) => (expect) => {
+    expect(actual).to.throw(Error, 'lt requires a maximum number to compare values to')
+  }
+
   return test('given `lt`', {
-    'when given a value greater than the minimum, it should return an error': (expect) => {
-      expect(lt20Bp.validate({ lt20: 21 }).err).to.not.be.null
-      expect(lt20Bp.validate({ lt20: 21 }).err.message)
-        .to.equal('Invalid sut: sut.lt20 must be less than 20')
+    'when defined (`lt(20)`)': {
+      'it should throw if the maximum is undefined':
+        expectToThrow(() => { blueprint('sut', { lt20: lt() }) }),
+      'it should throw if the maximum is null':
+        expectToThrow(() => { blueprint('sut', { lt20: lt(null) }) }),
+      'it should throw if the maximum is NaN':
+        expectToThrow(() => { blueprint('sut', { lt20: lt('string') }) })
     },
-    'when given a value equal to the minimum, it should return an error': (expect) => {
-      expect(lt20Bp.validate({ lt20: 20 }).err).to.not.be.null
-      expect(lt20Bp.validate({ lt20: 20 }).err.message)
-        .to.equal('Invalid sut: sut.lt20 must be less than 20')
+    'when `blueprint.validate` is called': {
+      'it should return a value if the value is less than the maximum':
+        expectValue({ lt20: 19 }, lt20Bp.validate({ lt20: 19 })),
+      'it should return an error if the value is equal to the maximum':
+        expectError(lt20Bp.validate({ lt20: 20 })),
+      'it should return an error if the value is less than the maximum':
+        expectError(lt20Bp.validate({ lt20: 21 })),
+      'it should return an error if the value is undefined':
+        expectError(lt20Bp.validate({ lt20: undefined })),
+      'it should return an error if the value is null':
+        expectError(lt20Bp.validate({ lt20: null })),
+      'it should return an error if the value is NaN':
+        expectError(lt20Bp.validate({ lt20: 'string' })),
+      'it should return an error if the value is not strictly a number':
+        expectError(lt20Bp.validate({ lt20: '19' }))
     },
-    'when given a value less than the minimum': {
-      when: () => lt20Bp.validate({ lt20: 19 }),
-      'it should NOT return an error': (expect) => (err, actual) => {
-        expect(err).to.be.null
-        expect(actual.err).to.be.null
-      },
-      'it should return the value': (expect) => (err, actual) => {
-        expect(err).to.be.null
-        expect(actual.value.lt20).to.equal(19)
-      }
+    'when the `optional` prefix is used, it should allow null and undefined': (expect) => {
+      const lt20Bp = blueprint('sut', {
+        lt20: lt(20),
+        maybeLt20: optional.lt(20)
+      })
+      expect(lt20Bp.validate({ lt20: 19 }).err).to.be.null
+      expect(lt20Bp.validate({ lt20: 19 }).value.maybeLt20).to.be.undefined
+      expect(lt20Bp.validate({ lt20: 19, maybeLt20: null }).value.maybeLt20).to.be.null
     }
   })
 }

--- a/src/validators/numbers-lte.test.js
+++ b/src/validators/numbers-lte.test.js
@@ -1,37 +1,58 @@
 module.exports = (test) => {
-  const { blueprint, lte } = test.sut
+  const { blueprint, lte, optional } = test.sut
 
   const lte20Bp = blueprint('sut', {
     lte20: lte(20)
   })
 
+  const expectValue = (expected, actual) => (expect) => {
+    expect(actual.err).to.be.null
+    expect(actual.value).to.deep.equal(expected)
+  }
+
+  const expectError = (actual) => (expect) => {
+    expect(actual.err).to.not.be.null
+    expect(actual.err.message)
+      .to.equal('Invalid sut: sut.lte20 must be less than, or equal to 20')
+  }
+
+  const expectToThrow = (actual) => (expect) => {
+    expect(actual).to.throw(Error, 'lte requires a maximum number to compare values to')
+  }
+
   return test('given `lte`', {
-    'when given a value greater than the minimum, it should return an error': (expect) => {
-      expect(lte20Bp.validate({ lte20: 21 }).err).to.not.be.null
-      expect(lte20Bp.validate({ lte20: 21 }).err.message)
-        .to.equal('Invalid sut: sut.lte20 must be less than, or equal to 20')
+    'when defined (`lte(20)`)': {
+      'it should throw if the maximum is undefined':
+        expectToThrow(() => { blueprint('sut', { lte20: lte() }) }),
+      'it should throw if the maximum is null':
+        expectToThrow(() => { blueprint('sut', { lte20: lte(null) }) }),
+      'it should throw if the maximum is NaN':
+        expectToThrow(() => { blueprint('sut', { lte20: lte('string') }) })
     },
-    'when given a value equal to the minimum': {
-      when: () => lte20Bp.validate({ lte20: 20 }),
-      'it should NOT return an error': (expect) => (err, actual) => {
-        expect(err).to.be.null
-        expect(actual.err).to.be.null
-      },
-      'it should return the value': (expect) => (err, actual) => {
-        expect(err).to.be.null
-        expect(actual.value.lte20).to.equal(20)
-      }
+    'when `blueprint.validate` is called': {
+      'it should return a value if the value is less than the maximum':
+        expectValue({ lte20: 19 }, lte20Bp.validate({ lte20: 19 })),
+      'it should return a value if the value is equal to the maximum':
+      expectValue({ lte20: 20 }, lte20Bp.validate({ lte20: 20 })),
+      'it should return an error if the value is less than the maximum':
+        expectError(lte20Bp.validate({ lte20: 21 })),
+      'it should return an error if the value is undefined':
+        expectError(lte20Bp.validate({ lte20: undefined })),
+      'it should return an error if the value is null':
+        expectError(lte20Bp.validate({ lte20: null })),
+      'it should return an error if the value is NaN':
+        expectError(lte20Bp.validate({ lte20: 'string' })),
+      'it should return an error if the value is not strictly a number':
+        expectError(lte20Bp.validate({ lte20: '19' }))
     },
-    'when given a value less than the minimum': {
-      when: () => lte20Bp.validate({ lte20: 19 }),
-      'it should NOT return an error': (expect) => (err, actual) => {
-        expect(err).to.be.null
-        expect(actual.err).to.be.null
-      },
-      'it should return the value': (expect) => (err, actual) => {
-        expect(err).to.be.null
-        expect(actual.value.lte20).to.equal(19)
-      }
+    'when the `optional` prefix is used, it should allow null and undefined': (expect) => {
+      const lte20Bp = blueprint('sut', {
+        lte20: lte(20),
+        maybeLte20: optional.lte(20)
+      })
+      expect(lte20Bp.validate({ lte20: 19 }).err).to.be.null
+      expect(lte20Bp.validate({ lte20: 19 }).value.maybeLte20).to.be.undefined
+      expect(lte20Bp.validate({ lte20: 19, maybeLte20: null }).value.maybeLte20).to.be.null
     }
   })
 }

--- a/src/validators/numbers-range.test.js
+++ b/src/validators/numbers-range.test.js
@@ -1,5 +1,5 @@
 module.exports = (test) => {
-  const { blueprint, range } = test.sut
+  const { blueprint, range, optional } = test.sut
 
   return test('given a `range`', {
     'with `lt`, and `gt`': {
@@ -183,6 +183,15 @@ module.exports = (test) => {
       'it should throw': (expect) => (err) => {
         expect(err).to.not.be.null
       }
+    },
+    'when the `optional` prefix is used, it should allow null and undefined': (expect) => {
+      const rangeBp = blueprint('sut', {
+        range: range({ gt: 10, lt: 20 }),
+        maybeRange: optional.range({ gt: 10, lt: 20 })
+      })
+      expect(rangeBp.validate({ range: 19 }).err).to.be.null
+      expect(rangeBp.validate({ range: 19 }).value.maybeRange).to.be.undefined
+      expect(rangeBp.validate({ range: 19, maybeRange: null }).value.maybeRange).to.be.null
     }
   })
 }

--- a/src/validators/numbers.js
+++ b/src/validators/numbers.js
@@ -1,70 +1,94 @@
 module.exports = {
   name: 'numberValidators',
-  factory: () => {
+  factory: (is) => {
     'use strict'
 
-    const gt = (min) => ({ key, value }) => {
-      if (value > min) {
-        return {
-          err: null,
-          value
-        }
+    const gt = (min) => {
+      if (is.not.number(min)) {
+        throw new Error('gt requires a minimum number to compare values to')
       }
 
-      return {
-        err: new Error(`${key} must be greater than ${min}`),
-        value: null
+      return ({ key, value }) => {
+        if (is.number(value) && value > min) {
+          return {
+            err: null,
+            value
+          }
+        }
+
+        return {
+          err: new Error(`${key} must be greater than ${min}`),
+          value: null
+        }
       }
     }
 
-    const gte = (min) => ({ key, value }) => {
-      if (value >= min) {
-        return {
-          err: null,
-          value
-        }
+    const gte = (min) => {
+      if (is.not.number(min)) {
+        throw new Error('gte requires a minimum number to compare values to')
       }
 
-      return {
-        err: new Error(`${key} must be greater than, or equal to ${min}`),
-        value: null
+      return ({ key, value }) => {
+        if (is.number(value) && value >= min) {
+          return {
+            err: null,
+            value
+          }
+        }
+
+        return {
+          err: new Error(`${key} must be greater than, or equal to ${min}`),
+          value: null
+        }
       }
     }
 
-    const lt = (max) => ({ key, value }) => {
-      if (value < max) {
-        return {
-          err: null,
-          value
-        }
+    const lt = (max) => {
+      if (is.not.number(max)) {
+        throw new Error('lt requires a maximum number to compare values to')
       }
 
-      return {
-        err: new Error(`${key} must be less than ${max}`),
-        value: null
+      return ({ key, value }) => {
+        if (is.number(value) && value < max) {
+          return {
+            err: null,
+            value
+          }
+        }
+
+        return {
+          err: new Error(`${key} must be less than ${max}`),
+          value: null
+        }
       }
     }
 
-    const lte = (max) => ({ key, value }) => {
-      if (value <= max) {
-        return {
-          err: null,
-          value
-        }
+    const lte = (max) => {
+      if (is.not.number(max)) {
+        throw new Error('lte requires a maximum number to compare values to')
       }
 
-      return {
-        err: new Error(`${key} must be less than, or equal to ${max}`),
-        value: null
+      return ({ key, value }) => {
+        if (is.number(value) && value <= max) {
+          return {
+            err: null,
+            value
+          }
+        }
+
+        return {
+          err: new Error(`${key} must be less than, or equal to ${max}`),
+          value: null
+        }
       }
     }
 
     const range = (options) => {
       if (!options) {
         throw new Error('You must specify a range')
-      } else if (isNaN(options.gt) && isNaN(options.gte)) {
+      } else if (is.not.number(options.gt) && is.not.number(options.gte)) {
         throw new Error('You must specify `gt`, or `gte` {number} when defining a range')
-      } else if (isNaN(options.lt) && isNaN(options.lte)) {
+      } else if (is.not.number(options.lt) && is.not.number(options.lte)) {
         throw new Error('You must specify `lt`, or `lte` {number} when defining a range')
       }
 
@@ -82,12 +106,32 @@ module.exports = {
       }
     }
 
+    const optional = (comparator) => (input) => {
+      const validator = comparator(input)
+
+      return (context) => {
+        const { value } = context
+        if (is.nullOrUndefined(value)) {
+          return { err: null, value }
+        } else {
+          return validator(context)
+        }
+      }
+    }
+
     return {
       gt,
       gte,
       lt,
       lte,
-      range
+      range,
+      optional: {
+        gt: optional(gt),
+        gte: optional(gte),
+        lt: optional(lt),
+        lte: optional(lte),
+        range: optional(range)
+      }
     }
   }
 }

--- a/src/validators/register-common-types.js
+++ b/src/validators/register-common-types.js
@@ -1,6 +1,9 @@
 module.exports = {
   name: 'registerCommonTypes',
-  factory: (is, { registerType }) => {
+  factory: (is, Blueprint) => {
+    'use strict'
+
+    const { registerType } = Blueprint
     const types = [
       'function',
       'object',

--- a/src/validators/register-decimals.js
+++ b/src/validators/register-decimals.js
@@ -1,6 +1,10 @@
 module.exports = {
   name: 'registerDecimals',
-  factory: (is, { registerValidator }) => {
+  factory: (is, Blueprint) => {
+    'use strict'
+
+    const { registerValidator } = Blueprint
+
     // support up to 15 decimal places for decimal precision
     for (let i = 1; i <= 15; i += 1) {
       registerValidator(`decimal:${i}`, ({ key, value }) => {

--- a/src/validators/register-expressions.js
+++ b/src/validators/register-expressions.js
@@ -1,10 +1,14 @@
 module.exports = {
   name: 'registerExpressions',
-  factory: ({ registerValidator }) => {
+  factory: (Blueprint) => {
+    'use strict'
+
+    const { registerValidator } = Blueprint
+
     registerValidator('expression', (regex) => ({ key, value }) => {
       return regex.test(value) === true
-        ? { err: null, value: value }
-        : { err: new Error(`${key} does not match ${regex.toString()}`), value: null }
+        ? { value: value }
+        : { err: new Error(`${key} does not match ${regex.toString()}`) }
     })
   }
 }

--- a/src/validators/register-expressions.test.js
+++ b/src/validators/register-expressions.test.js
@@ -3,17 +3,10 @@ module.exports = (test) => {
 
   return test('given `blueprint (expressions)`', {
     'it should support regular expressions': (expect) => {
-      const expected = {
-        type: 'book'
-      }
-      const actual = blueprint('sut', {
-        type: /^book$/i
-      }).validate(expected)
-      const actualInvalid = blueprint('sut', {
-        type: /^book$/i
-      }).validate({
-        type: 'person'
-      })
+      const expected = { type: 'book' }
+      const bp = blueprint('sut', { type: /^book$/i })
+      const actual = bp.validate(expected)
+      const actualInvalid = bp.validate({ type: 'person' })
 
       expect(actual.err).to.be.null
       expect(actual.value).to.deep.equal(expected)

--- a/test-ts.ts
+++ b/test-ts.ts
@@ -1,4 +1,5 @@
 // make sure tsc can build this
+import { expect } from 'chai'
 import {
   IValueOrError,
   IBlueprint,
@@ -12,6 +13,11 @@ import {
   gt, gte, lt, lte, range, optional,
   is
 } from './index'
+
+expect(is.string('str'), `is.string('str') should work`).to.equal(true)
+expect(is.not.string(1), `is.not.string(1) should work`).to.equal(true)
+expect(is.func(() => true), `is.func(() => true should work`).to.equal(true)
+expect(is.not.func('str'), `is.not.func('str') should work`).to.equal(true)
 
 const isCharBool: Validator = (context: IValidatorArg): boolean => {
   return typeof context.value === 'string' && context.value.length === 1
@@ -33,40 +39,30 @@ const isCharVal: Validator = (context: IValidatorArg): IValueOrError => {
   }
 }
 
-const registrations: IValueOrError[] = [
-  registerValidator('oneChar', isCharBool),
-  registerValidator('oneChar2', isCharVal),
-  registerType('char', isCharBool),
-  registerType('char2', isCharVal)
-]
+registerValidator('oneChar', isCharBool),
+registerValidator('oneChar2', isCharVal),
+registerType('char', isCharBool),
+registerType('char2', isCharVal)
+registerExpression('productType', /^book|movie$/)
 
-registrations.forEach((reg) => {
-  if (reg.err) {
-    throw reg.err
-  }
-})
-
-const myCharsBp: IBlueprint = blueprint('myChars', {
+const myCharsBp: IBlueprint = registerBlueprint('myChars', {
   a: 'oneChar',
   b: 'oneChar2',
   c: 'char',
   d: 'char2'
 })
 
-registrations.push(registerBlueprint('myChars', myCharsBp))
-registrations.push(registerExpression('productType', /^book|movie$/))
-
-registrations.forEach((reg) => {
-  if (reg.err) {
-    throw reg.err
-  }
-})
+expect(myCharsBp.name).to.equal('myChars')
 
 const myModelBp: IBlueprint = blueprint('myModel', {
   prop1: 'string',
   prop2: 'number',
   prop3: 'myChars',
   prop4: 'productType',
+  prop5: 'oneChar',
+  prop6: 'oneChar2',
+  prop7: 'char',
+  prop8: 'char2',
   gt: gt(20),
   gte: gte(20),
   lt: lt(20),
@@ -79,6 +75,7 @@ const myModelBp: IBlueprint = blueprint('myModel', {
   maybeRange: optional.range({ gt: 10, lt: 20 })
 })
 
+expect(myModelBp.name).to.equal('myModel')
 
 const result: IValueOrError = myModelBp.validate({
   prop1: 'hello world!',
@@ -89,33 +86,22 @@ const result: IValueOrError = myModelBp.validate({
     c: 'c',
     d: 'd'
   },
-  prop4: 'book'
+  prop4: 'book',
+  prop5: 'a',
+  prop6: 'b',
+  prop7: 'c',
+  prop8: 'd',
+  gt: 21,
+  gte: 21,
+  lt: 19,
+  lte: 19,
+  range: 15,
+  maybeGt: null,
+  maybeGte: undefined,
+  maybeLt: null,
+  maybeLte: undefined,
+  maybeRange: null
 })
 
-if (result.err) {
-  throw result.err
-}
-
-console.log({
-  assert: `is.string('str')`,
-  expected: true,
-  actual: is.string('str')
-})
-
-console.log({
-  assert: `is.not.string(1)`,
-  expected: true,
-  actual: is.string(1)
-})
-
-console.log({
-  assert: `is.function('str')`,
-  expected: false,
-  actual: is.function('str')
-})
-
-console.log({
-  assert: `is.not.function(1)`,
-  expected: false,
-  actual: is.function(1)
-})
+expect(result.err).to.be.null
+console.log('ALL TYPESCRIPT TESTS PASSED')

--- a/test.ts
+++ b/test.ts
@@ -1,0 +1,121 @@
+// make sure tsc can build this
+import {
+  IValueOrError,
+  IBlueprint,
+  IValidatorArg,
+  Validator,
+  blueprint,
+  registerValidator,
+  registerType,
+  registerBlueprint,
+  registerExpression,
+  gt, gte, lt, lte, range, optional,
+  is
+} from './index'
+
+const isCharBool: Validator = (context: IValidatorArg): boolean => {
+  return typeof context.value === 'string' && context.value.length === 1
+}
+
+const isCharVal: Validator = (context: IValidatorArg): IValueOrError => {
+  if (typeof context.value === 'string' && context.value.length === 1) {
+    return {
+      err: null,
+      messages: null,
+      value: context.value
+    }
+  }
+
+  return {
+    err: new Error('BOOM!'),
+    messages: ['BOOM!'],
+    value: context.value
+  }
+}
+
+const registrations: IValueOrError[] = [
+  registerValidator('oneChar', isCharBool),
+  registerValidator('oneChar2', isCharVal),
+  registerType('char', isCharBool),
+  registerType('char2', isCharVal)
+]
+
+registrations.forEach((reg) => {
+  if (reg.err) {
+    throw reg.err
+  }
+})
+
+const myCharsBp: IBlueprint = blueprint('myChars', {
+  a: 'oneChar',
+  b: 'oneChar2',
+  c: 'char',
+  d: 'char2'
+})
+
+registrations.push(registerBlueprint('myChars', myCharsBp))
+registrations.push(registerExpression('productType', /^book|movie$/))
+
+registrations.forEach((reg) => {
+  if (reg.err) {
+    throw reg.err
+  }
+})
+
+const myModelBp: IBlueprint = blueprint('myModel', {
+  prop1: 'string',
+  prop2: 'number',
+  prop3: 'myChars',
+  prop4: 'productType',
+  gt: gt(20),
+  gte: gte(20),
+  lt: lt(20),
+  lte: lte(20),
+  range: range({ gt: 10, lt: 20 }),
+  maybeGt: optional.gt(20),
+  maybeGte: optional.gte(20),
+  maybeLt: optional.lt(20),
+  maybeLte: optional.lte(20),
+  maybeRange: optional.range({ gt: 10, lt: 20 })
+})
+
+
+const result: IValueOrError = myModelBp.validate({
+  prop1: 'hello world!',
+  prop2: 42,
+  prop3: {
+    a: 'a',
+    b: 'b',
+    c: 'c',
+    d: 'd'
+  },
+  prop4: 'book'
+})
+
+if (result.err) {
+  throw result.err
+}
+
+console.log({
+  assert: `is.string('str')`,
+  expected: true,
+  actual: is.string('str')
+})
+
+console.log({
+  assert: `is.not.string(1)`,
+  expected: true,
+  actual: is.string(1)
+})
+
+console.log({
+  assert: `is.function('str')`,
+  expected: false,
+  actual: is.function('str')
+})
+
+console.log({
+  assert: `is.not.function(1)`,
+  expected: false,
+  actual: is.function(1)
+})

--- a/tmp/testts.js
+++ b/tmp/testts.js
@@ -1,0 +1,66 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+// make sure tsc can build this
+const chai_1 = require("chai");
+const index_1 = require("./index");
+chai_1.expect(index_1.is.string('str'), `is.string('str') should work`).to.equal(true);
+chai_1.expect(index_1.is.not.string(1), `is.not.string(1) should work`).to.equal(true);
+chai_1.expect(index_1.is.func(() => true), `is.func(() => true should work`).to.equal(true);
+chai_1.expect(index_1.is.not.func('str'), `is.not.func('str') should work`).to.equal(true);
+const isCharBool = (context) => {
+    return typeof context.value === 'string' && context.value.length === 1;
+};
+const isCharVal = (context) => {
+    if (typeof context.value === 'string' && context.value.length === 1) {
+        return {
+            err: null,
+            messages: null,
+            value: context.value
+        };
+    }
+    return {
+        err: new Error('BOOM!'),
+        messages: ['BOOM!'],
+        value: context.value
+    };
+};
+index_1.registerValidator('oneChar', isCharBool),
+    index_1.registerValidator('oneChar2', isCharVal),
+    index_1.registerType('char', isCharBool),
+    index_1.registerType('char2', isCharVal);
+const myCharsBp = index_1.blueprint('myChars', {
+    a: 'oneChar',
+    b: 'oneChar2',
+    c: 'char',
+    d: 'char2'
+});
+index_1.registerBlueprint('myChars', myCharsBp);
+index_1.registerExpression('productType', /^book|movie$/);
+const myModelBp = index_1.blueprint('myModel', {
+    prop1: 'string',
+    prop2: 'number',
+    prop3: 'myChars',
+    prop4: 'productType',
+    gt: index_1.gt(20),
+    gte: index_1.gte(20),
+    lt: index_1.lt(20),
+    lte: index_1.lte(20),
+    range: index_1.range({ gt: 10, lt: 20 }),
+    maybeGt: index_1.optional.gt(20),
+    maybeGte: index_1.optional.gte(20),
+    maybeLt: index_1.optional.lt(20),
+    maybeLte: index_1.optional.lte(20),
+    maybeRange: index_1.optional.range({ gt: 10, lt: 20 })
+});
+const result = myModelBp.validate({
+    prop1: 'hello world!',
+    prop2: 42,
+    prop3: {
+        a: 'a',
+        b: 'b',
+        c: 'c',
+        d: 'd'
+    },
+    prop4: 'book'
+});
+chai_1.expect(result.err).to.be.null;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,9 +3,10 @@
     "module": "CommonJS",
     "target": "es2017",
     "lib": ["ES2017", "DOM"],
-    "outDir": "tmp",
-    "sourceMap": true,
+    "outDir": ".",
+    "sourceMap": false,
     "strict": true
   },
-  "include": ["./test.ts"]
+  "include": ["./test-ts.ts"],
+  "exclude": []
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "module": "CommonJS",
+    "target": "es2017",
+    "lib": ["ES2017", "DOM"],
+    "outDir": "tmp",
+    "sourceMap": true,
+    "strict": true
+  },
+  "include": ["./test.ts"]
+}


### PR DESCRIPTION
* Expands the TypeScript type definitions to include more of the library, and adds tests to verify the type definitions
* Adds `registerExpression`, which allows you to register validators with just a regular expression
* Improves consistency (when to throw, common ValueOrError model)
* Adds better test coverage
* Stops supporting non-number astonishment in gt, gte, lt, lte, and
range (i.e. when NaN is fuzzy)
* Improves documentation