### PR TITLE
feat: Default from input

### DIFF
--- a/src/blueprint.js
+++ b/src/blueprint.js
@@ -441,13 +441,13 @@ module.exports = {
       let from
       const validator = comparatorToValidator(comparator)
 
-      const valueOrDefaultValue = (value) => {
+      const valueOrDefaultValue = (context) => {
         if (is.function(defaultVal)) {
-          return { value: defaultVal() }
+          return { value: defaultVal(context) }
         } else if (is.defined(defaultVal)) {
           return { value: defaultVal }
         } else {
-          return { value }
+          return { value: context.value }
         }
       }
 
@@ -465,9 +465,8 @@ module.exports = {
           context = ctx
         }
 
-        const { value } = context
-        if (is.nullOrUndefined(value)) {
-          return valueOrDefaultValue(value)
+        if (is.nullOrUndefined(context.value)) {
+          return valueOrDefaultValue(context)
         } else {
           return validator(context)
         }


### PR DESCRIPTION
**Feature suggestion:**
Provide the input context to a defaulter function (similar to context provision for the validator). When used to sanitize API return objects a default value can be dependent on the rest of the input structure. 

**Example Use Case:**
Object containing a number of arrays that should be the same length. App now requires an additional property with a same length array but the database return value is missing this (legacy entry). A value defaulter can now be used to provide a default array with a matching length. 

