### PR TITLE
fix: fixes the publish action

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "pre-push": [
     "lint",
-    "test",
+    "test:ci",
     "pre-push"
   ],
   "repository": {


### PR DESCRIPTION
The pre-push configuration was running tests with the nyan reporter which can't be used in CI. The publish action pushes to latest at present so the ci version of the tests needs to be used.